### PR TITLE
Removed RTTI from the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,9 @@
 *.out
 *.app
 
-#
+# Cmake user presets
+CMakeUserPresets.json
+
+# Build folders
 /build/*
+build.bak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(FrameGraph
   "include/fg/Blackboard.inl"
   "include/fg/GraphvizWriter.hpp"
   "include/fg/Fwd.hpp"
+  "include/fg/TypeId.hpp"
   "src/FrameGraph.cpp"
   "src/PassNode.cpp"
   "src/GraphvizWriter.cpp"

--- a/build.ps1
+++ b/build.ps1
@@ -13,8 +13,8 @@
 # compiler.runtime=dynamic
 # compiler.version=193
 # os=Windows
-# (compiler.version) and compiler.cppstd might change in the future, but that is OK)
-# This pforiel is actually the release profile, so just rename the file to vs-2022-release
+# (compiler.version and compiler.cppstd might change in the future, but that is OK)
+# This pforile is actually the release profile, so just rename the file to vs-2022-release
 # Make a copy of it and call it vs-2022-debug
 # In the debug profile change the 'build_type' from 'Release' to 'Debug'
 # You are done, you can invoke this script :)

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,27 @@
+# You need conan to be able to run this script, and for conan you need python
+# Once python is installed, you can install conan with pip
+# python3 -m pip install conan
+# Then you need to specify two conan profiles, one for debug one for release build
+# Invoke 'conan profile detect'
+# This will create a default profile under ${HOME}/.conan2/profiles/default,
+# with the following content (given you have Visual Studio installed):
+# [settings]
+# arch=x86_64
+# build_type=Release
+# compiler=msvc
+# compiler.cppstd=20
+# compiler.runtime=dynamic
+# compiler.version=193
+# os=Windows
+# (compiler.version) and compiler.cppstd might change in the future, but that is OK)
+# This pforiel is actually the release profile, so just rename the file to vs-2022-release
+# Make a copy of it and call it vs-2022-debug
+# In the debug profile change the 'build_type' from 'Release' to 'Debug'
+# You are done, you can invoke this script :)
+# The built library will be placed under build/lib/Debug and /build/lib/Release
+
+conan install . --profile vs-2022-debug --build=missing
+conan install . --profile vs-2022-release --build=missing
+cmake . --preset conan-default
+cmake --build --preset conan-release
+cmake --build --preset conan-debug

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,9 @@
+[requires]
+catch2/3.10.0
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[layout]
+cmake_layout

--- a/include/fg/Blackboard.hpp
+++ b/include/fg/Blackboard.hpp
@@ -1,8 +1,8 @@
 #pragma once
-
-#include <typeindex>
 #include <any>
 #include <unordered_map>
+
+#include "fg/TypeId.hpp"
 
 class FrameGraphBlackboard {
 public:
@@ -25,18 +25,7 @@ public:
   template <typename T> [[nodiscard]] bool has() const;
 
 private:
-  static uint32_t GetNextTypeId() {
-    static uint32_t nextTypeId;
-
-    return nextTypeId++;
-  }
-  template<typename T>
-  static uint32_t GetTypeId() {
-    static uint32_t typeId = GetNextTypeId();
-
-    return typeId;
-  }
-  std::unordered_map<uint32_t, std::any> m_storage;
+  std::unordered_map<TypeId, std::any> m_storage;
 };
 
 #include "fg/Blackboard.inl"

--- a/include/fg/Blackboard.hpp
+++ b/include/fg/Blackboard.hpp
@@ -25,7 +25,18 @@ public:
   template <typename T> [[nodiscard]] bool has() const;
 
 private:
-  std::unordered_map<std::type_index, std::any> m_storage;
+  static uint32_t GetNextTypeId() {
+    static uint32_t nextTypeId;
+
+    return nextTypeId++;
+  }
+  template<typename T>
+  static uint32_t GetTypeId() {
+    static uint32_t typeId = GetNextTypeId();
+
+    return typeId;
+  }
+  std::unordered_map<uint32_t, std::any> m_storage;
 };
 
 #include "fg/Blackboard.inl"

--- a/include/fg/Blackboard.inl
+++ b/include/fg/Blackboard.inl
@@ -3,15 +3,15 @@
 template <typename T, typename... Args>
 inline T &FrameGraphBlackboard::add(Args &&...args) {
   assert(!has<T>());
-  return m_storage[typeid(T)].emplace<T>(T{std::forward<Args>(args)...});
+  return m_storage[GetTypeId<T>()].emplace<T>(T{std::forward<Args>(args)...});
 }
 
 template <typename T> const T &FrameGraphBlackboard::get() const {
   assert(has<T>());
-  return std::any_cast<const T &>(m_storage.at(typeid(T)));
+  return std::any_cast<const T &>(m_storage.at(GetTypeId<T>()));
 }
 template <typename T> const T *FrameGraphBlackboard::try_get() const {
-  auto it = m_storage.find(typeid(T));
+  auto it = m_storage.find(GetTypeId<T>());
   return it != m_storage.cend() ? std::any_cast<const T>(&it->second) : nullptr;
 }
 
@@ -26,7 +26,7 @@ template <typename T> inline T *FrameGraphBlackboard::try_get() {
 
 template <typename T> inline bool FrameGraphBlackboard::has() const {
   if constexpr (__cplusplus >= 202002L)
-    return m_storage.contains(typeid(T));
+    return m_storage.contains(GetTypeId<T>());
   else
-    return m_storage.find(typeid(T)) != m_storage.cend();
+    return m_storage.find(GetTypeId<T>()) != m_storage.cend();
 }

--- a/include/fg/ResourceEntry.hpp
+++ b/include/fg/ResourceEntry.hpp
@@ -3,6 +3,8 @@
 #include "fg/TypeTraits.hpp"
 #include <memory>
 
+#include "TypeId.hpp"
+
 // Wrapper around a virtual resource.
 class ResourceEntry final {
   friend class FrameGraph;
@@ -57,6 +59,8 @@ private:
     virtual void preWrite(uint32_t flags, void *) = 0;
 
     virtual std::string toString() const = 0;
+
+    virtual TypeId getTypeId() const = 0;
   };
   template <typename T> struct Model final : Concept {
     Model(const typename T::Desc &, T &&);
@@ -82,6 +86,8 @@ private:
     }
 
     std::string toString() const override;
+
+    TypeId getTypeId() const override;
 
     const typename T::Desc descriptor;
     T resource;

--- a/include/fg/ResourceEntry.inl
+++ b/include/fg/ResourceEntry.inl
@@ -32,9 +32,11 @@ inline ResourceEntry::ResourceEntry(const Type type, uint32_t id,
       m_concept{std::make_unique<Model<T>>(desc, std::forward<T>(obj))} {}
 
 template <typename T> inline auto *ResourceEntry::_getModel() const {
-  auto *model = dynamic_cast<Model<T> *>(m_concept.get());
-  assert(model && "Invalid type");
-  return model;
+  using ModelType = Model<T>;
+
+  assert(GetTypeId<ModelType>() == m_concept->getTypeId() && "Invalid type");
+
+  return static_cast<ModelType*>(m_concept.get());
 }
 
 //
@@ -65,3 +67,9 @@ inline std::string ResourceEntry::Model<T>::toString() const {
   else
     return "";
 }
+
+template <typename T>
+TypeId ResourceEntry::Model<T>::getTypeId() const {
+  return GetTypeId<Model>();
+}
+

--- a/include/fg/TypeId.hpp
+++ b/include/fg/TypeId.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <cstdint>
+
+using TypeId = uint32_t;
+
+inline TypeId GetNextTypeId() {
+  static uint32_t nextTypeId;
+
+  return nextTypeId++;
+}
+
+template<typename T>
+static uint32_t GetTypeId() {
+  static uint32_t typeId = GetNextTypeId();
+
+  return typeId;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Catch2 CONFIG REQUIRED)
 
 add_executable(tests "test.cpp")
-target_link_libraries(tests PRIVATE fg::FrameGraph Catch2::Catch2)
+target_link_libraries(tests PRIVATE fg::FrameGraph Catch2::Catch2WithMain)
 
 include(CTest)
 include(Catch)

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include <catch2/catch_test_macros.hpp>
 #include "fg/FrameGraph.hpp"
 #include "fg/Blackboard.hpp"
 #include <fstream>
@@ -28,7 +28,6 @@ struct FrameGraphTexture {
   FrameGraphTexture(FrameGraphTexture &&) noexcept = default;
 
   void create(const Desc &, void *) {
-    static auto lastId = 0;
     id = ++lastId;
   }
   void destroy(const Desc &, void *) {}
@@ -40,8 +39,12 @@ struct FrameGraphTexture {
   }
 
   static const char *toString(const Desc &) { return "<I>texture</I>"; }
+  static void resetIds() { lastId = 0; }
 
   int32_t id{-1};
+
+private:
+  static inline int32_t lastId = 0;
 };
 
 #if __cplusplus >= 202002L
@@ -76,6 +79,7 @@ TEST_CASE("Basic graph with side-effect", "[FrameGraph]") {
     FrameGraphResource bar;
     mutable bool executed{false};
   };
+  FrameGraphTexture::resetIds();
   auto &testPass = fg.addCallbackPass<TestPass>(
     "Test pass",
     [&fg](FrameGraph::Builder &builder, TestPass &data) {
@@ -301,5 +305,3 @@ TEST_CASE("Copy", "[Blackboard]") {
 
   CHECK(copy.get<Data>().value != data.value);
 }
-
-int main(int argc, char *argv[]) { return Catch::Session().run(argc, argv); }


### PR DESCRIPTION
Instead of `typeid` now the code uses its own type id generation.
It is very basic, but can create unique IDs for every type.
It is not thread safe, and cannot be used between runs (e.g. do not save it to disk).
Instead of `dynamic_cast` the code now also uses type IDs, and if they match a simple `static_cast` is used.